### PR TITLE
Add location for autocomplete prediction biasing

### DIFF
--- a/client/src/components/Search/index.js
+++ b/client/src/components/Search/index.js
@@ -24,7 +24,9 @@ export default class Search extends Component {
     this.setState({value: event.target.value});
     // process autocomplete request and update list
     axios.post(`${API_SERVER}/search/autocomplete`, {
-      input: this.state.value,
+      input: this.state.value,      
+      lat: this.props.position.lat,
+      lng: this.props.position.lng,
     }).then((response) => {
       const status = response.data.status;
       const predictions = response.data.predictions;


### PR DESCRIPTION
Pass lat/lng values to autocomplete api from client for prediction biasing

## Issue Number:  #248 

## Issue Description:
fix search autocomplete to get user geolocation instead of server
### Summary of solution:
1.  Passing lat & lng values from client to backend autocomplete api for prediction biasing


### Can this issue be closed?
Yes
### Should any new issues be added as a result of this solution?
No
### Have you named your branch in a descriptive way? Remember to name your branch in a unique and descriptive manner in order to properly reflect the issue or feature.
Yes, autocomplete-geocodepissue
### Thanks for contributing!
