### PR TITLE
add geolocation to manifest permissions

### DIFF
--- a/client/src/manifest.json
+++ b/client/src/manifest.json
@@ -6,6 +6,7 @@
   "orientation": "portrait",
   "background_color": "#2196F3",
   "theme_color": "#2196F3",
+  "permissions": ["geolocation"],
   "icons": [{
      "src": "client/src/assets/icons/android-chrome-192x192.png",
        "sizes": "128x128",


### PR DESCRIPTION
## Issue Number: 
247
## Issue Description:
declare permissions in manifest.json

### Summary of solution:
1. Added geolocation permission to client > src > manifest.json

### Can this issue be closed?
Yes

### Should any new issues be added as a result of this solution?

### Have you named your branch in a descriptive way? Remember to name your branch in a unique and descriptive manner in order to properly reflect the issue or feature.

Yes - manifest-permissions

### Thanks for contributing!
