### PR TITLE
fixed type error in search component

### DIFF
--- a/client/src/components/Search/index.js
+++ b/client/src/components/Search/index.js
@@ -27,8 +27,8 @@ export default class Search extends Component {
     // process autocomplete request and update list
     axios.post(`${API_SERVER}/search/autocomplete`, {
       input: this.state.value,      
-      lat: this.props.position.lat,
-      lng: this.props.position.lng,
+      lat: this.state.position.lat,
+      lng: this.state.position.lng,
     }).then((response) => {
       const status = response.data.status;
       const predictions = response.data.predictions;
@@ -47,8 +47,8 @@ export default class Search extends Component {
     event.preventDefault();
     axios.post(`${API_SERVER}/search/textsearch`, {
       input: this.state.value,
-      lat: this.props.position.lat,
-      lng: this.props.position.lng,
+      lat: this.state.position.lat,
+      lng: this.state.position.lng,
       }).then((response) => { 
         if(response.data.status == OK_STATUS)
         {

--- a/client/src/components/Search/index.js
+++ b/client/src/components/Search/index.js
@@ -13,8 +13,7 @@ export default class Search extends Component {
       predictions: [],
       placeIDs: [],
       descSubfields: [],
-      marker: null,
-      position: {},
+      marker: null
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -27,8 +26,8 @@ export default class Search extends Component {
     // process autocomplete request and update list
     axios.post(`${API_SERVER}/search/autocomplete`, {
       input: this.state.value,      
-      lat: this.state.position.lat,
-      lng: this.state.position.lng,
+      lat: this.props.position.lat,
+      lng: this.props.position.lng,
     }).then((response) => {
       const status = response.data.status;
       const predictions = response.data.predictions;
@@ -47,8 +46,8 @@ export default class Search extends Component {
     event.preventDefault();
     axios.post(`${API_SERVER}/search/textsearch`, {
       input: this.state.value,
-      lat: this.state.position.lat,
-      lng: this.state.position.lng,
+      lat: this.props.position.lat,
+      lng: this.props.position.lng,
       }).then((response) => { 
         if(response.data.status == OK_STATUS)
         {


### PR DESCRIPTION
## Issue Number: N/A

## Issue Description: N/A

### Summary of solution:
In its calls to the backend API, the search component was sending this.props.position.lat and this.props.position.lng for lat and lng fields respectively.  However, if you look at the constructor it is storing the position object in this.state.  Consequently, type errors were showing up in the console preventing the backed even hitting the google api to get results.  

### Can this issue be closed?
yes

### Should any new issues be added as a result of this solution?
No
### Have you named your branch in a descriptive way? Remember to name your branch in a unique and descriptive manner in order to properly reflect the issue or feature.
Yes search_component_type_err
