### PR TITLE
151 router google directions

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3300,6 +3300,11 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decode-google-map-polyline": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/decode-google-map-polyline/-/decode-google-map-polyline-1.0.1.tgz",
+      "integrity": "sha1-2acIQQ206N6gPS3wDm6WMVeE7FE="
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,7 @@
     },
     "dependencies": {
         "axios": "^0.18.0",
+        "decode-google-map-polyline": "^1.0.1",
         "leaflet": "^1.3.1",
         "leaflet-easybutton": "^2.3.0",
         "leaflet-routing-machine": "^3.2.8",

--- a/client/src/js/lrm-google.js
+++ b/client/src/js/lrm-google.js
@@ -1,0 +1,81 @@
+// node_module imports
+const L = require('leaflet');
+const decodePolyline = require('decode-google-map-polyline');
+
+// app module imports
+const { makeRequest, BASE_ENDPOINTS } = require('./server-requests-utils')
+
+L.Routing = L.Routing || {};
+
+L.Routing.Google = L.Class.extend({
+  options: {
+
+  },
+
+  initialize: function(options) {
+    L.Util.setOptions(this, options);
+  },
+
+  route: function(waypoints, callback, context, options) {
+    // TODO - handle waypoints that include stopovers
+    const origin = `${waypoints[0].latLng.lat},${waypoints[0].latLng.lng}`;
+    const destination = `${waypoints[1].latLng.lat},${waypoints[1].latLng.lng}`;
+
+    console.log('waypoints: ', waypoints);
+    console.log('context: ', context);
+    console.log('options: ', options);
+    console.log('callback: ', callback);
+
+    // get directions
+    makeRequest('POST', BASE_ENDPOINTS.directions, '', {
+      origin,
+      destination,
+    }).then((response) => {
+      console.log('google api response:\n', response);
+      this._processResponse(response, waypoints, callback, context, options);
+    }).catch((err) => {
+      console.log('google api error: ', err);
+      callback.call(context || callback, err);
+    });
+  },
+
+  _processResponse: function(response, inputWaypoints, callback, context, options) {
+    const routes = [];
+
+    // iterate through each google route
+    response.data.routes.forEach((respRoute) => {
+      const route = {};
+
+      // store route specific data
+      route.inputWaypoints = inputWaypoints;
+      route.name = respRoute.summary;
+      route.summary = {
+        totalTime: respRoute.legs[0].duration.value,
+        totalDistance: respRoute.legs[0].distance.value,
+      };
+
+      // store step specific data for each leg
+      route.coordinates = []; // equivalent to polylines
+      route.instructions = [];
+
+      // iterate through each step of the leg for given route
+      respRoute.legs[0].steps.forEach((step) => {
+        const point = decodePolyline(step.polyline.points);
+        route.coordinates.push(...point);
+        route.instructions.push({
+          distance: step.distance.value,
+          time: step.duration.value,
+          text: step.html_instructions
+        });
+      });
+
+      routes.push(route);
+    });
+
+    callback.call(context || callback, null, routes);
+  }
+});
+
+L.Routing.google = function(options={}) {
+  return new L.Routing.Google(options);
+};

--- a/client/src/js/lrm-google.js
+++ b/client/src/js/lrm-google.js
@@ -21,15 +21,11 @@ L.Routing.Google = L.Class.extend({
     const origin = `${waypoints[0].latLng.lat},${waypoints[0].latLng.lng}`;
     const destination = `${waypoints[1].latLng.lat},${waypoints[1].latLng.lng}`;
 
-    console.log('waypoints: ', waypoints);
-    console.log('context: ', context);
-    console.log('options: ', options);
-    console.log('callback: ', callback);
-
     // get directions
     makeRequest('POST', BASE_ENDPOINTS.directions, '', {
       origin,
       destination,
+      units: 'metric',
     }).then((response) => {
       console.log('google api response:\n', response);
       this._processResponse(response, waypoints, callback, context, options);

--- a/client/src/js/server-requests-utils.js
+++ b/client/src/js/server-requests-utils.js
@@ -25,6 +25,7 @@ export const BASE_ENDPOINTS = { // Key-value pairs for existing base server endp
   userReset: '/users/reset-password',
   userUpdate: '/users/update',
   geocode: '/map/geocode',
+  directions: '/map/directions',
 }
 
 export const token = {

--- a/client/src/routes/directions/index.js
+++ b/client/src/routes/directions/index.js
@@ -12,8 +12,9 @@ const ERROR_STATUS = 500;
 import '../../../node_modules/leaflet/dist/leaflet.css';
 import '../../../node_modules/leaflet-routing-machine/dist/leaflet-routing-machine.css';
 import L from '../../js/leaflet-tileLayer-pouchdb-cached';
-import Routing from '../../../node_modules/leaflet-routing-machine/src/index.js';
+import '../../../node_modules/leaflet-routing-machine/src/index.js';
 import 'leaflet-easybutton';
+import '../../js/lrm-google';
 
 /**
 * TIle layer configuration and attribution constants
@@ -64,7 +65,7 @@ export default class Directions extends Component {
     const map = L.map('map');
     const selfDir = this;
     map.addLayer(OSM_TILE_LAYER);
-    this.control = Routing.control({
+    this.control = L.Routing.control({
       waypoints: [
         L.latLng(this.state.origin.lat,
           this.state.origin.lng),
@@ -76,6 +77,7 @@ export default class Directions extends Component {
       showAlternatives: true,
       show: false,
       collapsible: false,
+      router: L.Routing.google(),
     }).addTo(map);
 
     this.control.on('routeselected', (e) => {

--- a/controllers/google-api-controller.js
+++ b/controllers/google-api-controller.js
@@ -287,6 +287,9 @@ exports.placeDetails = (appReq, appRes) => {
  * @param {string} transit_routing_preference - (optional) Specifies preferences for transit
  * routes. Using this parameter, you can bias the options returned, rather than accepting
  * the default best route chosen by the API. [less_walking, fewer_transfers]
+ * @param {string} units - specifies the unit system for displaying results:
+ *   - metric: km/meters
+ *   - imperial: miles/feet
  *
  * @returns {Object} Default google maps json response
  *   (https://google-developers.appspot.com/maps/documentation/directions/intro#DirectionsResponseElements)
@@ -313,6 +316,7 @@ exports.directions = (appReq, appRes) => {
     traffic_model: trafficModel,
     transit_mode: appReq.body.transit_mode || '',
     transit_routing_preference: transitRoutingPref || '',
+    units: appReq.body.units || '',
   };
   const BASE_URL = 'https://maps.googleapis.com/maps/api/directions/json?';
   const queryString = convertToQueryString(params);


### PR DESCRIPTION
## Issue Number:
#151 
## Issue Description:
Extend lrm routing to use google directions api for directions.

### Summary of solution:
1. Minor refactor
2. Add new module that extends `L.Routing` to use make requests to backend server and consumer google directions api response instead of default OSRM router.

### Can this issue be closed?
No - working towards caching logic
### Should any new issues be added as a result of this solution?

### Have you named your branch in a descriptive way? Remember to name your branch in a unique and descriptive manner in order to properly reflect the issue or feature.

### Thanks for contributing!
