### PR TITLE
Search Component componentwillreceiveprops

### DIFF
--- a/client/src/components/Search/index.js
+++ b/client/src/components/Search/index.js
@@ -102,16 +102,3 @@ export default class Search extends Component {
     );
   }
 }
-
-function average(...nums) {
-    if (nums.length === 0)
-        return 0;
-    
-    let total = 0;
-    
-    for (let num of nums) {
-        total += num;
-    }
-    
-    return total / nums.length;
-}

--- a/client/src/components/Search/index.js
+++ b/client/src/components/Search/index.js
@@ -75,6 +75,14 @@ export default class Search extends Component {
     }
   }
 
+  componentWillReceiveProps(nextProps, prevState) {
+    if (this.props.position === null ||
+        (nextProps.position.lat !== this.props.position.lat &&
+         nextProps.position.lng !== this.props.position.lng)) {
+          this.props = nextProps;
+        }
+  }
+
   render() {
     // pass props to children components
     const childWithProps = this.props.children.map((child) => {
@@ -93,4 +101,17 @@ export default class Search extends Component {
       </form>
     );
   }
+}
+
+function average(...nums) {
+    if (nums.length === 0)
+        return 0;
+    
+    let total = 0;
+    
+    for (let num of nums) {
+        total += num;
+    }
+    
+    return total / nums.length;
 }


### PR DESCRIPTION
Adding `componentwillreceiveprops` to `Search` component so that when `navigator.geolocation.getCurrentPosition` returns it updates the props of the `Search` component properly.

I am up for discussion on this being new to Preact and React. I did a little research to find out how to update props from other components and was led to this method. I wasn't sure if setting the `props` like I did is the best manner for things.